### PR TITLE
🐛 Fix deprecation warning for 'go get'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install
 For Debian based distriubutions install package _libpcap-dev_
 
 ```
-$ go get github.com/sachaos/tcpterm
+$ go install github.com/sachaos/tcpterm
 ```
 
 Usage


### PR DESCRIPTION
go get: installing executables with 'go get' in module mode is deprecated.
Use 'go install pkg@version' instead.
For more information, see https://golang.org/doc/go-get-install-deprecation
or run 'go help get' or 'go help install'.